### PR TITLE
Added link of Flutter Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Application that presents information about food recipes from [TheMealDb](https:
 - [Flutter Widget of the Week](https://www.youtube.com/playlist?list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG)
 - [Flutter Crash Course](https://fluttercrashcourse.com)
 - [DevonFw Flutter Guide](https://github.com/devonfw-forge/devonfw4flutter) 
+- [Flutter Developer Roadmap](https://roadmap.sh/flutter) 
 
 # Official Link to Flutter Community available on different platforms
 


### PR DESCRIPTION
Hi @oliver-gomes,

I came across your repository [flutter-guide](https://github.com/oliver-gomes/flutter-guide) and found it to be a valuable resource for Flutter enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Flutter Roadmap"](https://roadmap.sh/flutter). I took the initiative to submit a ["Pull Request"](https://github.com/oliver-gomes/flutter-guide/pull/30) adding it in Recommended Learning Resource section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz